### PR TITLE
Upgrade paramiko version to 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.30.0
+* Bump Paramiko to 3.5.1 [#52](https://github.com/singer-io/tap-sftp/pull/52)
+
 ## 1.2.3
 * Bump singer-encodings [#51](https://github.com/singer-io/tap-sftp/pull/51)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     py_modules=["tap_sftp"],
     install_requires=[
         "singer-python==5.13.2",
-        'paramiko==3.4.0',
+        'paramiko==3.5.1',
         'backoff==1.10.0',
         'singer-encodings==0.1.4',
     ],
@@ -22,7 +22,7 @@ setup(
             'nose'
         ],
         'test': [
-            'paramiko==2.6.0'
+            'paramiko==3.5.1'
         ]
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-sftp",
-    version="1.2.3",
+    version="1.3.0",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
- Update paramiko 3.4.0 -> 3.51 (Add support for AES-GCM encryption ciphers (128 and 256 bit variants) 
   ref: [paramiko changelog](https://www.paramiko.org/changelog.html#:~:text=Add%20support%20for%20AES%2DGCM%20encryption%20ciphers%20(128%20and%20256%20bit%20variants))

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
