### PR TITLE
Bump singer-encodings from 0.1.4 to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.1
+  * Bump requests to 2.33.0 (CVE-2026-25645)
+
 # Changelog
 
 ## 1.30.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-sftp",
-    version="1.3.0",
+    version="1.3.1",
     description="Singer.io tap for extracting data",
     author="Stitch",
     url="http://singer.io",
@@ -13,7 +13,8 @@ setup(
         "singer-python==5.13.2",
         'paramiko==3.5.1',
         'backoff==1.10.0',
-        'singer-encodings==0.5.0',
+        'singer-encodings==0.5.0',,
+        'requests>=2.33.0'
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "singer-python==5.13.2",
         'paramiko==3.5.1',
         'backoff==1.10.0',
-        'singer-encodings==0.1.4',
+        'singer-encodings==0.5.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Bump to a newer patch version for compatibility.